### PR TITLE
Small Fixes

### DIFF
--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -45,12 +45,10 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
     if not adt_service.sites:
         LOG.error("ADT's Pulse service returned NO sites: %s", adt_service)
         return
-
     for site in adt_service.sites:
         if not site.zones:
             LOG.error("ADT's Pulse service returned NO zones (sensors) for site: %s ... %s", adt_service.sites, adt_service)
             continue
-            
         for zone in site.zones:
             sensors.append( ADTPulseSensor(hass, adt_service, site, zone) )
 
@@ -67,8 +65,7 @@ class ADTPulseSensor(BinarySensorEntity):
         self.hass = hass
         self._adt_service = adt_service
         self._site = site
-
-        self._zone_id = zone_details.get('id')
+        self._zone_id = zone_details.get('id_')
         self._name = zone_details.get('name')
         self._update_zone_status(zone_details)
 

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -3,7 +3,7 @@
     "name": "ADT Pulse",
     "documentation": "https://github.com/rsnodgrass/hass-adtpulse/",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "requirements": [
 	"pyadtpulse>=1.0.0",
 	"beautifulsoup4>=4.9.0",

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -7,7 +7,8 @@
     "requirements": [
 	"pyadtpulse>=1.0.0",
 	"beautifulsoup4>=4.9.0",
-	"backoff>=1.10.0"
+	"backoff>=1.10.0",
+    "uvloop>=0.17.0"
     ],
     "dependencies": [],
     "codeowners": [],


### PR DESCRIPTION
Changes were as follows:

- Updated binary sensor to use "id_" instead of id when fetching the device id. This was causing None to be returned and thus causing duplicate sensor IDs.
- Added additional dependencies in the manifest.json file that are required for pyadtpulse to work properly.
- Increased the version in manifest.json for tagging reasons

@rlippmann - FYI 