### PR TITLE
0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.3 (2023-10-12)
+
+* bump pyadtpulse to 1.1.3.  This should fix alarm not updating issue
+* add force stay and force away services
+* add relogin service
+* refactor code to use base entity.  This should cause most entities to become unavailable if the gateway goes offline
+* disallow invalid alarm state changes
+* revert alarm card functionality.  All states will be available, but exceptions will be thrown if an invalid state is requested.
+
 ## 0.3.2 (2023-10-08)
 
 Alarm control panel updates:

--- a/custom_components/adtpulse/__init__.py
+++ b/custom_components/adtpulse/__init__.py
@@ -43,7 +43,7 @@ LOG = getLogger(__name__)
 
 SUPPORTED_PLATFORMS = ["alarm_control_panel", "binary_sensor"]
 
-CONFIG_SCHEMA = config_entry_only_config_schema
+# CONFIG_SCHEMA = config_entry_only_config_schema
 
 
 async def async_setup(

--- a/custom_components/adtpulse/__init__.py
+++ b/custom_components/adtpulse/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceRegistry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.config_entry_flow import FlowResult
 from homeassistant.helpers.config_validation import config_entry_only_config_schema
@@ -136,6 +136,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.stop)
     )
     entry.async_on_unload(entry.add_update_listener(options_listener))
+
+    async def handle_relogin(dummy: str) -> None:  # pylint: disable=unused-argument
+        await service.async_quick_relogin()
+
+    hass.services.async_register(ADTPULSE_DOMAIN, "quick_relogin", handle_relogin)
     return True
 
 

--- a/custom_components/adtpulse/__init__.py
+++ b/custom_components/adtpulse/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import HomeAssistant, ServiceRegistry
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.config_entry_flow import FlowResult
 from homeassistant.helpers.config_validation import config_entry_only_config_schema

--- a/custom_components/adtpulse/__init__.py
+++ b/custom_components/adtpulse/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.config_entry_flow import FlowResult
+from homeassistant.helpers.config_validation import config_entry_only_config_schema
 from homeassistant.helpers.typing import ConfigType
 from pyadtpulse import PyADTPulse
 from pyadtpulse.const import (
@@ -41,6 +42,8 @@ from .coordinator import ADTPulseDataUpdateCoordinator
 LOG = getLogger(__name__)
 
 SUPPORTED_PLATFORMS = ["alarm_control_panel", "binary_sensor"]
+
+CONFIG_SCHEMA = config_entry_only_config_schema
 
 
 async def async_setup(

--- a/custom_components/adtpulse/__init__.py
+++ b/custom_components/adtpulse/__init__.py
@@ -43,7 +43,7 @@ LOG = getLogger(__name__)
 
 SUPPORTED_PLATFORMS = ["alarm_control_panel", "binary_sensor"]
 
-# CONFIG_SCHEMA = config_entry_only_config_schema
+CONFIG_SCHEMA = config_entry_only_config_schema(ADTPULSE_DOMAIN)
 
 
 async def async_setup(

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -34,15 +34,15 @@ from pyadtpulse.alarm_panel import (
 )
 from pyadtpulse.site import ADTPulseSite
 
-from . import (
+from .const import ADTPULSE_DATA_ATTRIBUTION, ADTPULSE_DOMAIN
+from .coordinator import ADTPulseDataUpdateCoordinator
+from .utils import (
     get_alarm_unique_id,
     get_gateway_unique_id,
     migrate_entity_name,
     zone_open,
     zone_trouble,
 )
-from .const import ADTPULSE_DATA_ATTRIBUTION, ADTPULSE_DOMAIN
-from .coordinator import ADTPulseDataUpdateCoordinator
 
 LOG = getLogger(__name__)
 

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -166,7 +166,9 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
         if self.state == action:
             LOG.warning("Attempting to set alarm to same state, ignoring")
             return
-        if action == STATE_ALARM_DISARMED:
+        if not self._gateway.is_online:
+            self._assumed_state = action
+        elif action == STATE_ALARM_DISARMED:
             self._assumed_state = STATE_ALARM_DISARMING
         else:
             self._assumed_state = STATE_ALARM_ARMING

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -131,15 +131,8 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
         return ALARM_ICON_MAP[self._alarm.status]
 
     @property
-    def supported_features(self) -> AlarmControlPanelEntityFeature | None:
+    def supported_features(self) -> AlarmControlPanelEntityFeature:
         """Return the list of supported features."""
-        if self.state != STATE_ALARM_DISARMED:
-            return None
-        retval = AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
-        if self._site.zones_as_dict is None:
-            return retval
-        if not system_can_be_armed(self._site):
-            return retval
         return (
             AlarmControlPanelEntityFeature.ARM_AWAY
             | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -66,6 +66,11 @@ ALARM_ICON_MAP = {
     ADT_ALARM_UNKNOWN: "mdi:shield-bug",
 }
 
+FORCE_ARM = "force arm"
+ARM_ERROR_MESSAGE = (
+    f"Pulse system cannot be armed due to opened/tripped zone - use {FORCE_ARM}"
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant, config: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -183,9 +188,7 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         if not system_can_be_armed(self._site):
-            raise HomeAssistantError(
-                "Pulse system cannot be armed due to tripped zone - use force arm"
-            )
+            raise HomeAssistantError(ARM_ERROR_MESSAGE)
         await self._perform_alarm_action(
             self._site.async_arm_home(), STATE_ALARM_ARMED_HOME
         )
@@ -193,9 +196,7 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         if not system_can_be_armed(self._site):
-            raise HomeAssistantError(
-                "Pulse system cannot be armed due to tripped zone - use force arm"
-            )
+            raise HomeAssistantError(ARM_ERROR_MESSAGE)
         await self._perform_alarm_action(
             self._site.async_arm_away(), STATE_ALARM_ARMED_AWAY
         )
@@ -204,7 +205,7 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
     async def async_alarm_arm_custom_bypass(self, code: str | None = None) -> None:
         """Send force arm command."""
         await self._perform_alarm_action(
-            self._site.async_arm_away(force_arm=True), "force arm"
+            self._site.async_arm_away(force_arm=True), FORCE_ARM
         )
 
     async def async_alarm_arm_force_stay(self) -> None:

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -40,8 +40,7 @@ from .utils import (
     get_alarm_unique_id,
     get_gateway_unique_id,
     migrate_entity_name,
-    zone_open,
-    zone_trouble,
+    system_can_be_armed,
 )
 
 LOG = getLogger(__name__)
@@ -138,9 +137,8 @@ class ADTPulseAlarm(
         retval = AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
         if self._site.zones_as_dict is None:
             return retval
-        for zone in self._site.zones_as_dict.values():
-            if zone_open(zone) or zone_trouble(zone):
-                return retval
+        if not system_can_be_armed(self._site):
+            return retval
         return (
             AlarmControlPanelEntityFeature.ARM_AWAY
             | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
@@ -190,12 +188,20 @@ class ADTPulseAlarm(
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
+        if not system_can_be_armed(self._site):
+            raise HomeAssistantError(
+                "Pulse system cannot be armed due to tripped zone" " - use force arm"
+            )
         await self._perform_alarm_action(
             self._site.async_arm_home(), STATE_ALARM_ARMED_HOME
         )
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
+        if not system_can_be_armed(self._site):
+            raise HomeAssistantError(
+                "Pulse system cannot be armed due to tripped zone" " - use force arm"
+            )
         await self._perform_alarm_action(
             self._site.async_arm_away(), STATE_ALARM_ARMED_AWAY
         )

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -251,6 +251,11 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
         """
         return None
 
+    @property
+    def available(self) -> bool:
+        """Alarm panel is always available even if gateway isn't."""
+        return True
+
     @callback
     def _handle_coordinator_update(self) -> None:
         LOG.debug(

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.config_validation import config_entry_only_config_schema
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -48,8 +47,6 @@ from .utils import (
 )
 
 LOG = getLogger(__name__)
-
-PLATFORM_SCHEMA = alarm.PLATFORM_SCHEMA.extend(config_entry_only_config_schema)
 
 ALARM_MAP = {
     ADT_ALARM_ARMING: STATE_ALARM_ARMING,

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.config_validation import config_entry_only_config_schema
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -48,6 +49,7 @@ from .utils import (
 
 LOG = getLogger(__name__)
 
+PLATFORM_SCHEMA = config_entry_only_config_schema
 ALARM_MAP = {
     ADT_ALARM_ARMING: STATE_ALARM_ARMING,
     ADT_ALARM_AWAY: STATE_ALARM_ARMED_AWAY,

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -49,7 +49,8 @@ from .utils import (
 
 LOG = getLogger(__name__)
 
-PLATFORM_SCHEMA = config_entry_only_config_schema
+PLATFORM_SCHEMA = alarm.PLATFORM_SCHEMA.extend(config_entry_only_config_schema)
+
 ALARM_MAP = {
     ADT_ALARM_ARMING: STATE_ALARM_ARMING,
     ADT_ALARM_AWAY: STATE_ALARM_ARMED_AWAY,

--- a/custom_components/adtpulse/base_entity.py
+++ b/custom_components/adtpulse/base_entity.py
@@ -1,11 +1,16 @@
 """ADT Pulse Entity Base class."""
 from __future__ import annotations
 
+from logging import getLogger
+from typing import Any, Mapping
+
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import LOG
+from .const import ADTPULSE_DATA_ATTRIBUTION
 from .coordinator import ADTPulseDataUpdateCoordinator
+
+LOG = getLogger(__name__)
 
 
 class ADTPulseEntity(CoordinatorEntity[ADTPulseDataUpdateCoordinator]):
@@ -19,14 +24,26 @@ class ADTPulseEntity(CoordinatorEntity[ADTPulseDataUpdateCoordinator]):
             name (str): entity name
         """
         self._name = name
-
+        # save references to commonly used objects
+        self._pulse_connection = coordinator.adtpulse
+        self._site = self._pulse_connection.site
+        self._gateway = self._site.gateway
+        self._alarm = self._site.alarm_control_panel
         self._attrs: dict = {}
         super().__init__(coordinator)
 
+    # Base level properties that can be overridden by subclasses
     @property
-    def name(self) -> str:
-        """Return the display name for this sensor."""
-        return self._name
+    def name(self) -> str | None:
+        """Return the display name for this sensor.
+
+        Should generally be none since using has_entity_name."""
+        return None
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Returns has_entity_name.  Should generally be true."""
+        return True
 
     @property
     def icon(self) -> str:
@@ -38,13 +55,25 @@ class ADTPulseEntity(CoordinatorEntity[ADTPulseDataUpdateCoordinator]):
         return "mdi:gauge"
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return the device state attributes."""
         return self._attrs
+
+    @property
+    def is_available(self) -> bool:
+        """Returns whether an entity is available.
+
+        Generally false if gateway is offline."""
+        return self._gateway.is_online
+
+    @property
+    def attribution(self) -> str:
+        """Return API data attribution."""
+        return ADTPULSE_DATA_ATTRIBUTION
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Call update method."""
-        LOG.debug(f"Scheduling update ADT Pulse entity {self._name}")
+        LOG.debug("Scheduling update ADT Pulse entity %s", self._name)
         # inform HASS that ADT Pulse data for this entity has been updated
         self.async_write_ha_state()

--- a/custom_components/adtpulse/base_entity.py
+++ b/custom_components/adtpulse/base_entity.py
@@ -60,7 +60,7 @@ class ADTPulseEntity(CoordinatorEntity[ADTPulseDataUpdateCoordinator]):
         return self._attrs
 
     @property
-    def is_available(self) -> bool:
+    def available(self) -> bool:
         """Returns whether an entity is available.
 
         Generally false if gateway is offline."""

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -31,8 +31,8 @@ from .utils import (
     get_alarm_unique_id,
     get_gateway_unique_id,
     migrate_entity_name,
-    zone_open,
-    zone_trouble,
+    zone_is_in_trouble,
+    zone_is_open,
 )
 
 LOG = getLogger(__name__)
@@ -212,8 +212,8 @@ class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
         """Return True if the binary sensor is on."""
         # sensor is considered tripped if the state is anything but OK
         if self._is_trouble_indicator:
-            return zone_trouble(self._my_zone)
-        return zone_open(self._my_zone)
+            return zone_is_in_trouble(self._my_zone)
+        return zone_is_open(self._my_zone)
 
     @property
     def device_class(self) -> BinarySensorDeviceClass:

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.config_validation import config_entry_only_config_schema
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -36,6 +37,8 @@ from .utils import (
 )
 
 LOG = getLogger(__name__)
+
+PLATFORM_SCHEMA = config_entry_only_config_schema
 
 # please keep these alphabetized to make changes easier
 ADT_DEVICE_CLASS_TAG_MAP = {

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -25,15 +25,15 @@ from homeassistant.util import as_local
 from pyadtpulse.site import ADTPulseSite
 from pyadtpulse.zones import ADTPulseZoneData
 
-from . import (
+from .const import ADTPULSE_DATA_ATTRIBUTION, ADTPULSE_DOMAIN
+from .coordinator import ADTPulseDataUpdateCoordinator
+from .utils import (
     get_alarm_unique_id,
     get_gateway_unique_id,
     migrate_entity_name,
     zone_open,
     zone_trouble,
 )
-from .const import ADTPULSE_DATA_ATTRIBUTION, ADTPULSE_DOMAIN
-from .coordinator import ADTPulseDataUpdateCoordinator
 
 LOG = getLogger(__name__)
 

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -273,7 +273,6 @@ class ADTPulseGatewaySensor(ADTPulseEntity, BinarySensorEntity):
         LOG.debug(
             "%s: adding gateway status sensor for site %s", ADTPULSE_DOMAIN, site.name
         )
-        self._gateway = site.gateway
         self._device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._name = f"ADT Pulse Gateway Status - Site: {site.name}"
         super().__init__(coordinator, self._name)

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any, Mapping
 
 from homeassistant.components.binary_sensor import (
+    PLATFORM_SCHEMA,
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
@@ -38,7 +39,7 @@ from .utils import (
 
 LOG = getLogger(__name__)
 
-PLATFORM_SCHEMA = config_entry_only_config_schema
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(config_entry_only_config_schema)
 
 # please keep these alphabetized to make changes easier
 ADT_DEVICE_CLASS_TAG_MAP = {

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -12,13 +12,11 @@ from datetime import datetime
 from typing import Any, Mapping
 
 from homeassistant.components.binary_sensor import (
-    PLATFORM_SCHEMA,
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.config_validation import config_entry_only_config_schema
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -38,8 +36,6 @@ from .utils import (
 )
 
 LOG = getLogger(__name__)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(config_entry_only_config_schema)
 
 # please keep these alphabetized to make changes easier
 ADT_DEVICE_CLASS_TAG_MAP = {

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -20,12 +20,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import as_local
 from pyadtpulse.site import ADTPulseSite
 from pyadtpulse.zones import ADTPulseZoneData
 
-from .const import ADTPULSE_DATA_ATTRIBUTION, ADTPULSE_DOMAIN
+from .base_entity import ADTPulseEntity
+from .const import ADTPULSE_DOMAIN
 from .coordinator import ADTPulseDataUpdateCoordinator
 from .utils import (
     get_alarm_unique_id,
@@ -103,9 +103,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ADTPulseZoneSensor(
-    CoordinatorEntity[ADTPulseDataUpdateCoordinator], BinarySensorEntity
-):
+class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
     """HASS zone binary sensor implementation for ADT Pulse."""
 
     # zone = {'id': 'sensor-12', 'name': 'South Office Motion',
@@ -167,7 +165,6 @@ class ADTPulseZoneSensor(
             )
         else:
             LOG.debug("%s: adding zone sensor for site %s", ADTPULSE_DOMAIN, site.id)
-        self._site = site
         self._zone_id = zone_id
         self._is_trouble_indicator = trouble_indicator
         self._my_zone = self._get_my_zone(site, zone_id)
@@ -186,10 +183,6 @@ class ADTPulseZoneSensor(
         if self._is_trouble_indicator:
             return "Trouble"
         return None
-
-    @property
-    def has_entity_name(self) -> bool:
-        return True
 
     @property
     def unique_id(self) -> str:
@@ -255,11 +248,6 @@ class ADTPulseZoneSensor(
             manufacturer="ADT",
         )
 
-    @property
-    def attribution(self) -> str:
-        """Return API data attribution."""
-        return ADTPULSE_DATA_ATTRIBUTION
-
     @callback
     def _handle_coordinator_update(self) -> None:
         LOG.debug(
@@ -271,9 +259,7 @@ class ADTPulseZoneSensor(
         self.async_write_ha_state()
 
 
-class ADTPulseGatewaySensor(
-    CoordinatorEntity[ADTPulseDataUpdateCoordinator], BinarySensorEntity
-):
+class ADTPulseGatewaySensor(ADTPulseEntity, BinarySensorEntity):
     """HASS Gateway Online Binary Sensor."""
 
     def __init__(self, coordinator: ADTPulseDataUpdateCoordinator, site: ADTPulseSite):
@@ -288,23 +274,14 @@ class ADTPulseGatewaySensor(
             "%s: adding gateway status sensor for site %s", ADTPULSE_DOMAIN, site.name
         )
         self._gateway = site.gateway
-        self._site = site
         self._device_class = BinarySensorDeviceClass.CONNECTIVITY
-        self._name = f"ADT Pulse Gateway Status - Site: {self._site.name}"
+        self._name = f"ADT Pulse Gateway Status - Site: {site.name}"
         super().__init__(coordinator, self._name)
 
     @property
     def is_on(self) -> bool:
         """Return if gateway is online."""
         return self._gateway.is_online
-
-    @property
-    def name(self) -> str | None:
-        return None
-
-    @property
-    def has_entity_name(self) -> bool:
-        return True
 
     # FIXME: Gateways only support one site?
     @property
@@ -317,11 +294,6 @@ class ADTPulseGatewaySensor(
         if self.is_on:
             return "mdi:lan-connect"
         return "mdi:lan-disconnect"
-
-    @property
-    def attribution(self) -> str | None:
-        """Return API data attribution."""
-        return ADTPULSE_DATA_ATTRIBUTION
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -8,7 +8,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rlippmann/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse>=1.1.2"
+        "pyadtpulse>=1.1.3"
     ],
-    "version": "0.3.2"
+    "version": "0.3.3"
 }

--- a/custom_components/adtpulse/services.yaml
+++ b/custom_components/adtpulse/services.yaml
@@ -7,3 +7,7 @@ force_away:
   target:
     entity:
       domain: alarm_control_panel
+
+quick_relogin:
+  name: "Relogin to Pulse"
+  description: "Performs a re-login to Pulse"

--- a/custom_components/adtpulse/services.yaml
+++ b/custom_components/adtpulse/services.yaml
@@ -1,0 +1,3 @@
+force_stay:
+
+force_away:

--- a/custom_components/adtpulse/services.yaml
+++ b/custom_components/adtpulse/services.yaml
@@ -1,3 +1,9 @@
 force_stay:
+  target:
+    entity:
+      domain: alarm_control_panel
 
 force_away:
+  target:
+    entity:
+      domain: alarm_control_panel

--- a/custom_components/adtpulse/strings.json
+++ b/custom_components/adtpulse/strings.json
@@ -38,5 +38,15 @@
         "min_relogin":"Pulse re-login Interval must be greater than 20 minutes",
         "max_keepalive":"Pulse keepalive Interval must be less than 15 minutes"
     }
+  },
+  "services": {
+    "force_stay": {
+      "name": "Alarm Force Stay",
+      "description": "Force arm Pulse in stay/home mode"
+    },
+    "force_away": {
+      "name": "Alarm Force Stay",
+      "description": "Force arm Pulse in away mode.  This is the same as arming custom bypass"
+    }
   }
 }

--- a/custom_components/adtpulse/strings.json
+++ b/custom_components/adtpulse/strings.json
@@ -45,7 +45,7 @@
       "description": "Force arm Pulse in stay/home mode"
     },
     "force_away": {
-      "name": "Alarm Force Stay",
+      "name": "Alarm Force Away",
       "description": "Force arm Pulse in away mode.  This is the same as arming custom bypass"
     }
   }

--- a/custom_components/adtpulse/strings.json
+++ b/custom_components/adtpulse/strings.json
@@ -47,6 +47,10 @@
     "force_away": {
       "name": "Alarm Force Away",
       "description": "Force arm Pulse in away mode.  This is the same as arming custom bypass"
+    },
+    "quick_relogin": {
+      "name": "Relogin to Pulse",
+      "description": "Performs a re-login to Pulse"
     }
   }
 }

--- a/custom_components/adtpulse/translations/en.json
+++ b/custom_components/adtpulse/translations/en.json
@@ -38,5 +38,15 @@
         "min_relogin":"Pulse re-login Interval must be greater than 20 minutes",
         "max_keepalive":"Pulse keepalive Interval must be less than 15 minutes"
     }
+  },
+  "services": {
+    "force_stay": {
+      "name": "Alarm Force Stay",
+      "description": "Force arm Pulse in stay/home mode"
+    },
+    "force_away": {
+      "name": "Alarm Force Stay",
+      "description": "Force arm Pulse in away mode.  This is the same as arming custom bypass"
+    }
   }
 }

--- a/custom_components/adtpulse/translations/en.json
+++ b/custom_components/adtpulse/translations/en.json
@@ -45,7 +45,7 @@
       "description": "Force arm Pulse in stay/home mode"
     },
     "force_away": {
-      "name": "Alarm Force Stay",
+      "name": "Alarm Force Away",
       "description": "Force arm Pulse in away mode.  This is the same as arming custom bypass"
     }
   }

--- a/custom_components/adtpulse/translations/en.json
+++ b/custom_components/adtpulse/translations/en.json
@@ -47,6 +47,10 @@
     "force_away": {
       "name": "Alarm Force Away",
       "description": "Force arm Pulse in away mode.  This is the same as arming custom bypass"
+    },
+    "quick_relogin": {
+      "name": "Relogin to Pulse",
+      "description": "Performs a re-login to Pulse"
     }
   }
 }

--- a/custom_components/adtpulse/utils.py
+++ b/custom_components/adtpulse/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+from homeassistant.util import slugify
 from pyadtpulse.const import STATE_OK, STATE_ONLINE
 from pyadtpulse.site import ADTPulseSite
 from pyadtpulse.zones import ADTPulseZoneData

--- a/custom_components/adtpulse/utils.py
+++ b/custom_components/adtpulse/utils.py
@@ -1,0 +1,65 @@
+"""ADT Pulse utility functions."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
+from pyadtpulse.const import STATE_OK, STATE_ONLINE
+from pyadtpulse.site import ADTPulseSite
+from pyadtpulse.zones import ADTPulseZoneData
+
+from .const import ADTPULSE_DOMAIN
+
+
+def migrate_entity_name(
+    hass: HomeAssistant, site: ADTPulseSite, platform_name: str, entity_uid: str
+) -> None:
+    """Migrate old entity names."""
+    registry = entity_registry.async_get(hass)
+    if registry is None:
+        return
+    # this seems backwards
+    entity_id = registry.async_get_entity_id(
+        platform_name,
+        ADTPULSE_DOMAIN,
+        entity_uid,
+    )
+    if entity_id is not None:
+        # change has_entity_name to True and set name to None for devices
+        registry.async_update_entity(entity_id, has_entity_name=True, name=None)
+        # rename site name to site id for entities which have site name
+        slugified_site_name = slugify(site.name)
+        if slugified_site_name in entity_id:
+            registry.async_update_entity(
+                entity_id, new_entity_id=entity_id.replace(slugified_site_name, site.id)
+            )
+
+
+def get_gateway_unique_id(site: ADTPulseSite) -> str:
+    """Get entity unique id for the gateway."""
+    return f"adt_pulse_gateway_{site.id}"
+
+
+def get_alarm_unique_id(site: ADTPulseSite) -> str:
+    """Get entity unique ID for alarm."""
+    return f"adt_pulse_alarm_{site.id}"
+
+
+def zone_open(zone: ADTPulseZoneData) -> bool:
+    """Determine if a zone is opened."""
+    return not zone.state == STATE_OK
+
+
+def zone_trouble(zone: ADTPulseZoneData) -> bool:
+    """Determine if a zone is in trouble state."""
+    return not zone.status == STATE_ONLINE
+
+
+def system_can_be_armed(site: ADTPulseSite) -> bool:
+    """Determine is the system is able to be armed without being forced."""
+    zones = site.zones_as_dict
+    if zones is None:
+        return False
+    for zone in zones:
+        if zone_open(zone) or zone_trouble(zone):
+            return False
+    return True

--- a/custom_components/adtpulse/utils.py
+++ b/custom_components/adtpulse/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 from pyadtpulse.const import STATE_OK, STATE_ONLINE
 from pyadtpulse.site import ADTPulseSite
@@ -15,7 +15,7 @@ def migrate_entity_name(
     hass: HomeAssistant, site: ADTPulseSite, platform_name: str, entity_uid: str
 ) -> None:
     """Migrate old entity names."""
-    registry = entity_registry.async_get(hass)
+    registry = er.async_get(hass)
     if registry is None:
         return
     # this seems backwards
@@ -47,12 +47,12 @@ def get_alarm_unique_id(site: ADTPulseSite) -> str:
 
 def zone_open(zone: ADTPulseZoneData) -> bool:
     """Determine if a zone is opened."""
-    return not zone.state == STATE_OK
+    return zone.state != STATE_OK
 
 
 def zone_trouble(zone: ADTPulseZoneData) -> bool:
     """Determine if a zone is in trouble state."""
-    return not zone.status == STATE_ONLINE
+    return zone.status != STATE_ONLINE
 
 
 def system_can_be_armed(site: ADTPulseSite) -> bool:

--- a/custom_components/adtpulse/utils.py
+++ b/custom_components/adtpulse/utils.py
@@ -60,7 +60,7 @@ def system_can_be_armed(site: ADTPulseSite) -> bool:
     zones = site.zones_as_dict
     if zones is None:
         return False
-    for zone in zones:
+    for zone in zones.values():
         if zone_open(zone) or zone_trouble(zone):
             return False
     return True

--- a/custom_components/adtpulse/utils.py
+++ b/custom_components/adtpulse/utils.py
@@ -45,12 +45,12 @@ def get_alarm_unique_id(site: ADTPulseSite) -> str:
     return f"adt_pulse_alarm_{site.id}"
 
 
-def zone_open(zone: ADTPulseZoneData) -> bool:
+def zone_is_open(zone: ADTPulseZoneData) -> bool:
     """Determine if a zone is opened."""
     return zone.state != STATE_OK
 
 
-def zone_trouble(zone: ADTPulseZoneData) -> bool:
+def zone_is_in_trouble(zone: ADTPulseZoneData) -> bool:
     """Determine if a zone is in trouble state."""
     return zone.status != STATE_ONLINE
 
@@ -61,6 +61,6 @@ def system_can_be_armed(site: ADTPulseSite) -> bool:
     if zones is None:
         return False
     for zone in zones.values():
-        if zone_open(zone) or zone_trouble(zone):
+        if zone_is_open(zone) or zone_is_in_trouble(zone):
             return False
     return True


### PR DESCRIPTION
* bump pyadtpulse to 1.1.3.  This should fix alarm not updating issue
* add force stay and force away services
* add relogin service
* refactor code to use base entity.  This should cause most entities to become unavailable if the gateway goes offline
* disallow invalid alarm state changes
* revert alarm card functionality.  All states will be available, but exceptions will be thrown if an invalid state is requested.
