### PR TITLE
0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1 (2024-02-07)
+
+* bump pyadtpulse to 1.2.2.  This will perform a full re-login after 24 hours
+* have connection status show authentication errors
+
 ## 0.4.0 (2024-02-02)
 
 * bump pyadtpulse to 1.2.0.  This should provide more robust error handling and stability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1 (2024-02-07)
 
-* bump pyadtpulse to 1.2.3.  This will perform a full re-login after 24 hours
+* bump pyadtpulse to 1.2.5.  This will perform a full re-login approximately every 6 hours
 * have connection status show authentication errors
 
 ## 0.4.0 (2024-02-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-## 0.4.1 (2024-02-07)
+## 0.4.1 (2024-02-23)
 
-* bump pyadtpulse to 1.2.5.  This will perform a full re-login approximately every 6 hours
+* bump pyadtpulse to 1.2.6.
+  This will:
+  * perform a full re-login approximately every 6 hours
+  * speed up zone and alarm update times
+  * allow Home Assistant to just refresh updated zones/alarm instead all all entities
 * have connection status show authentication errors
+* correctly handle coordinator update authentication errors to perform configuration reauthentication flow
 
 ## 0.4.0 (2024-02-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1 (2024-02-07)
 
-* bump pyadtpulse to 1.2.2.  This will perform a full re-login after 24 hours
+* bump pyadtpulse to 1.2.3.  This will perform a full re-login after 24 hours
 * have connection status show authentication errors
 
 ## 0.4.0 (2024-02-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1 (2024-02-23)
 
-* bump pyadtpulse to 1.2.6.
+* bump pyadtpulse to 1.2.7.
   This will:
   * perform a full re-login approximately every 6 hours
   * speed up zone and alarm update times

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 0.4.1 (2024-02-23)
+## 0.4.1 (2024-02-24)
 
 * bump pyadtpulse to 1.2.7.
   This will:
   * perform a full re-login approximately every 6 hours
   * speed up zone and alarm update times
   * allow Home Assistant to just refresh updated zones/alarm instead all all entities
+  * fix various "you have not logged in yet" errors
 * have connection status show authentication errors
 * correctly handle coordinator update authentication errors to perform configuration reauthentication flow
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ To enable ADT Pulse, add the following integration like any other integration in
 
 #### Step to Get Your Trusted Device
 
+**<ins>Important:</ins>** If you are logged into ADT Pulse with the same fingerprint, the first login will be logged out when the second login is attempted.  For this reason it is recommended that you not use the same machine/browser that you would normally use for logging into Pulse when you generate the fingerprint.
+
 1. Go to the ADT Pulse Login page but do not login.
 2. Open up the developer tools for your browser and make sure you enable the network capturing option and recording is enabled
-3. Login to your account
+3. Login to your account.
 4. If the device isn't trusted, it will prompt you for a code, afterwards you will be asked if you want to trust the device. Give it a name and click Save and Continue.
 
 ![ADT Save Device](https://github.com/rsnodgrass/hass-adtpulse/blob/master/docs/adt_save_device.jpg?raw=true)

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -39,7 +39,7 @@ from pyadtpulse.site import ADTPulseSite
 
 from .base_entity import ADTPulseEntity
 from .const import ADTPULSE_DOMAIN
-from .coordinator import ADTPulseDataUpdateCoordinator
+from .coordinator import ADTPulseDataUpdateCoordinator, ALARM_CONTEXT
 from .utils import (
     get_alarm_unique_id,
     get_gateway_unique_id,
@@ -110,7 +110,7 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
         LOG.debug("%s: adding alarm control panel for %s", ADTPULSE_DOMAIN, site.id)
         self._name = f"ADT Alarm Panel - Site {site.id}"
         self._assumed_state: str | None = None
-        super().__init__(coordinator, self._name)
+        super().__init__(coordinator, ALARM_CONTEXT)
 
     @property
     def state(self) -> str:

--- a/custom_components/adtpulse/alarm_control_panel.py
+++ b/custom_components/adtpulse/alarm_control_panel.py
@@ -266,6 +266,11 @@ class ADTPulseAlarm(ADTPulseEntity, alarm.AlarmControlPanelEntity):
         """Return the name of the sensor."""
         return None
 
+    @property
+    def code_arm_required(self) -> bool:
+        """Whether the code is required for arm actions."""
+        return False
+
     @callback
     def _handle_coordinator_update(self) -> None:
         LOG.debug(

--- a/custom_components/adtpulse/base_entity.py
+++ b/custom_components/adtpulse/base_entity.py
@@ -32,7 +32,7 @@ class ADTPulseEntity(CoordinatorEntity[ADTPulseDataUpdateCoordinator]):
         self._gateway = self._site.gateway
         self._alarm = self._site.alarm_control_panel
         self._attrs: dict = {}
-        super().__init__(coordinator)
+        super().__init__(coordinator, name)
 
     # Base level properties that can be overridden by subclasses
     @property

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -299,9 +299,9 @@ class ADTPulseGatewaySensor(ADTPulseEntity, BinarySensorEntity):
         return self._gateway.is_online
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the sensor."""
-        return self._name
+        return None
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -164,25 +164,30 @@ class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
         trouble_indicator: bool,
     ):
         """Initialize the binary_sensor."""
+        sensor_type = ""
         if trouble_indicator:
-            LOG.debug(
-                "%s: adding zone trouble sensor for site %s", ADTPULSE_DOMAIN, site.id
-            )
-        else:
-            LOG.debug("%s: adding zone sensor for site %s", ADTPULSE_DOMAIN, site.id)
+            sensor_type = "trouble"
+        LOG.debug(
+            "%s: adding zone %s sensor for site %s, zone %d",
+            ADTPULSE_DOMAIN,
+            sensor_type,
+            site.id,
+            zone_id,
+        )
         self._zone_id = zone_id
         self._is_trouble_indicator = trouble_indicator
         self._my_zone = self._get_my_zone(site, zone_id)
-        zone_context = ZONE_CONTEXT_PREFIX + str(self._zone_id)
+        self._zone_context = ZONE_CONTEXT_PREFIX + str(self._zone_id)
         if trouble_indicator:
             self._device_class = BinarySensorDeviceClass.PROBLEM
-            self._name = f"Trouble Sensor - {self._my_zone.name}"
-            zone_context += ZONE_TROUBLE_PREFIX
+            self._zone_context += ZONE_TROUBLE_PREFIX
         else:
             self._device_class = self._determine_device_class(self._my_zone)
             self._name = f"{self._my_zone.name}"
-        super().__init__(coordinator, zone_context)
-        LOG.debug("Created ADT Pulse '%s' sensor %s", self._device_class, self.name)
+        super().__init__(coordinator, self._zone_context)
+        LOG.debug(
+            "Created ADT Pulse '%s' sensor %s", self._device_class, self._zone_context
+        )
 
     @property
     def name(self) -> str | None:
@@ -258,8 +263,8 @@ class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         LOG.debug(
-            "Setting ADT Pulse zone %s to on = %s at timestamp %d",
-            self.name,
+            "Setting ADT Pulse %s to on = %s at timestamp %d",
+            self._zone_context,
             self.is_on,
             self._my_zone.last_activity_timestamp,
         )

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -27,7 +27,11 @@ from pyadtpulse.zones import ADTPulseZoneData
 
 from .base_entity import ADTPulseEntity
 from .const import ADTPULSE_DOMAIN
-from .coordinator import ADTPulseDataUpdateCoordinator
+from .coordinator import (
+    ADTPulseDataUpdateCoordinator,
+    ZONE_CONTEXT_PREFIX,
+    ZONE_TROUBLE_PREFIX,
+)
 from .utils import (
     get_alarm_unique_id,
     get_gateway_unique_id,
@@ -169,13 +173,15 @@ class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
         self._zone_id = zone_id
         self._is_trouble_indicator = trouble_indicator
         self._my_zone = self._get_my_zone(site, zone_id)
+        zone_context = ZONE_CONTEXT_PREFIX + str(self._zone_id)
         if trouble_indicator:
             self._device_class = BinarySensorDeviceClass.PROBLEM
             self._name = f"Trouble Sensor - {self._my_zone.name}"
+            zone_context += ZONE_TROUBLE_PREFIX
         else:
             self._device_class = self._determine_device_class(self._my_zone)
             self._name = f"{self._my_zone.name}"
-        super().__init__(coordinator, self._name)
+        super().__init__(coordinator, zone_context)
         LOG.debug("Created ADT Pulse '%s' sensor %s", self._device_class, self.name)
 
     @property

--- a/custom_components/adtpulse/binary_sensor.py
+++ b/custom_components/adtpulse/binary_sensor.py
@@ -186,7 +186,10 @@ class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
             self._name = f"{self._my_zone.name}"
         super().__init__(coordinator, self._zone_context)
         LOG.debug(
-            "Created ADT Pulse '%s' sensor %s", self._device_class, self._zone_context
+            "Created ADT Pulse '%s' sensor %s - %s",
+            self._device_class,
+            self._zone_context,
+            self._my_zone.name,
         )
 
     @property
@@ -263,9 +266,10 @@ class ADTPulseZoneSensor(ADTPulseEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         LOG.debug(
-            "Setting ADT Pulse %s to on = %s at timestamp %d",
+            "Setting ADT Pulse %s - %s to %s at timestamp %d",
             self._zone_context,
-            self.is_on,
+            self._my_zone.name,
+            "on" if self.is_on else "off",
             self._my_zone.last_activity_timestamp,
         )
         self.async_write_ha_state()

--- a/custom_components/adtpulse/config_flow.py
+++ b/custom_components/adtpulse/config_flow.py
@@ -152,8 +152,9 @@ class PulseConfigFlow(ConfigFlow, domain=ADTPULSE_DOMAIN):  # type: ignore
             ) as ex:
                 errors["base"] = "service_unavailable"
                 raise ConfigEntryNotReady from ex
-            except PulseConnectionError:
+            except PulseConnectionError as ex:
                 errors["base"] = "cannot_connect"
+                raise ConfigEntryNotReady from ex
             except Exception:  # pylint: disable=broad-except
                 LOG.exception("Unexpected exception")
                 errors["base"] = "unknown"

--- a/custom_components/adtpulse/coordinator.py
+++ b/custom_components/adtpulse/coordinator.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import datetime
-from logging import getLogger, DEBUG
+from logging import getLogger
 from asyncio import CancelledError, Task
 from typing import Any, Callable
 

--- a/custom_components/adtpulse/coordinator.py
+++ b/custom_components/adtpulse/coordinator.py
@@ -21,7 +21,7 @@ from .const import ADTPULSE_DOMAIN
 
 LOG = getLogger(__name__)
 
-ALARM_CONTEXT = "alarm"
+ALARM_CONTEXT = "Alarm"
 ZONE_CONTEXT_PREFIX = "Zone "
 ZONE_TROUBLE_PREFIX = " Trouble"
 

--- a/custom_components/adtpulse/coordinator.py
+++ b/custom_components/adtpulse/coordinator.py
@@ -24,7 +24,7 @@ LOG = getLogger(__name__)
 
 ALARM_CONTEXT = "alarm"
 ZONE_CONTEXT_PREFIX = "Zone "
-ZONE_TROUBLE_PREFIX = ZONE_CONTEXT_PREFIX + " Trouble"
+ZONE_TROUBLE_PREFIX = " Trouble"
 
 
 class ADTPulseDataUpdateCoordinator(DataUpdateCoordinator):

--- a/custom_components/adtpulse/coordinator.py
+++ b/custom_components/adtpulse/coordinator.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from logging import getLogger
+import datetime
+from logging import getLogger, DEBUG
 from asyncio import CancelledError, Task
+from typing import Any, Callable
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback, CALLBACK_TYPE
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util.dt import as_local, utc_from_timestamp
+from homeassistant.util.dt import as_local, utc_from_timestamp, utcnow
 from pyadtpulse.exceptions import (
     PulseExceptionWithBackoff,
     PulseExceptionWithRetry,
@@ -19,6 +21,10 @@ from pyadtpulse.pyadtpulse_async import PyADTPulseAsync
 from .const import ADTPULSE_DOMAIN
 
 LOG = getLogger(__name__)
+
+ALARM_CONTEXT = "alarm"
+ZONE_CONTEXT_PREFIX = "Zone "
+ZONE_TROUBLE_PREFIX = ZONE_CONTEXT_PREFIX + " Trouble"
 
 
 class ADTPulseDataUpdateCoordinator(DataUpdateCoordinator):
@@ -39,11 +45,47 @@ class ADTPulseDataUpdateCoordinator(DataUpdateCoordinator):
             LOG,
             name=ADTPULSE_DOMAIN,
         )
+        self._listener_dictionary: dict[str, CALLBACK_TYPE] = {}
 
     @property
     def adtpulse(self) -> PyADTPulseAsync:
         """Return the ADT Pulse service object."""
         return self._adt_pulse
+
+    @callback
+    def async_add_listener(
+        self, update_callback: CALLBACK_TYPE, context: Any = None
+    ) -> Callable[[], None]:
+        """Listen for data updates."""
+        self._listener_dictionary[context] = update_callback
+        return super().async_add_listener(update_callback, context)
+
+    @callback
+    def async_update_listeners(self) -> None:
+        """Update listeners based update returned data."""
+
+        start_time = utcnow()
+        if not self.data:
+            super().async_update_listeners()
+            LOG.debug(
+                "%s: async_update_listeners took %s",
+                ADTPULSE_DOMAIN,
+                utcnow() - start_time,
+            )
+            return
+        data_to_update: tuple[bool, set[int]] = self.data
+        if data_to_update[0]:
+            self._listener_dictionary[ALARM_CONTEXT]()
+        for zones in data_to_update[1]:
+            self._listener_dictionary[ZONE_CONTEXT_PREFIX + str(zones)]()
+            self._listener_dictionary[
+                ZONE_CONTEXT_PREFIX + str(zones) + ZONE_TROUBLE_PREFIX
+            ]()
+        LOG.debug(
+            "%s: partial async_update_listeners took %s",
+            ADTPULSE_DOMAIN,
+            utcnow() - start_time,
+        )
 
     async def start(self) -> None:
         """Start ADT Pulse update coordinator.
@@ -70,10 +112,11 @@ class ADTPulseDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> None:
         """Fetch data from ADT Pulse."""
         while not self._shutdown_requested and not self.hass.is_stopping:
+            data = None
             LOG.debug("%s: coordinator waiting for updates", ADTPULSE_DOMAIN)
             update_exception: Exception | None = None
             try:
-                await self._adt_pulse.wait_for_update()
+                data = await self._adt_pulse.wait_for_update()
             except PulseLoginException as ex:
                 LOG.error(
                     "%s: ADT Pulse login failed during coordinator update: %s",
@@ -116,6 +159,6 @@ class ADTPulseDataUpdateCoordinator(DataUpdateCoordinator):
                         self.async_update_listeners()
                 else:
                     self.last_exception = None
-                    self.async_set_updated_data(None)
+                    self.async_set_updated_data(data)
 
             LOG.debug("%s: coordinator received update notification", ADTPULSE_DOMAIN)

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.6"
+        "pyadtpulse==1.2.7"
     ],
     "version": "0.4.1"
 }

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.1"
+        "pyadtpulse==1.2.2"
     ],
     "version": "0.4.1"
 }

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.5"
+        "pyadtpulse==1.2.6b1"
     ],
     "version": "0.4.1"
 }

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.3"
+        "pyadtpulse==1.2.5"
     ],
     "version": "0.4.1"
 }

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.6b1"
+        "pyadtpulse==1.2.6"
     ],
     "version": "0.4.1"
 }

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -4,11 +4,12 @@
     "codeowners": ["@rsnodgrass", "@rlippmann"],
     "config_flow": true,
     "dependencies": [],
+    "integration_type": "hub",
     "documentation": "https://github.com/rsnodgrass/hass-adtpulse/",
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.0"
+        "pyadtpulse==1.2.1"
     ],
-    "version": "0.4.0"
+    "version": "0.4.1"
 }

--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse==1.2.2"
+        "pyadtpulse==1.2.3"
     ],
     "version": "0.4.1"
 }

--- a/custom_components/adtpulse/sensor.py
+++ b/custom_components/adtpulse/sensor.py
@@ -19,6 +19,9 @@ from pyadtpulse.exceptions import (
     PulseGatewayOfflineError,
     PulseServerConnectionError,
     PulseServiceTemporarilyUnavailableError,
+    PulseAuthenticationError,
+    PulseMFARequiredError,
+    PulseNotLoggedInError,
 )
 
 from .base_entity import ADTPulseEntity
@@ -37,6 +40,9 @@ COORDINATOR_EXCEPTION_MAP: dict[type[Exception], tuple[str, str]] = {
         "Service Temporarily Unavailable",
         "mdi:lan-pending",
     ),
+    PulseAuthenticationError: ("Authentication Error", "mdi:account-alert"),
+    PulseMFARequiredError: ("MFA Required", "mdi:account-reactivate"),
+    PulseNotLoggedInError: ("Not Logged In", "mdi:account-off"),
 }
 CONNECTION_STATUS_OK = ("Connection OK", "mdi:hand-okay")
 CONNECTION_STATUSES = list(COORDINATOR_EXCEPTION_MAP.values())

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "ADT Pulse",
   "homeassistant": "2024.2.0",
-  "render_readme": true
+  "render_readme": true,
+  "country": ["US", "CA"]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "ADT Pulse",
-  "homeassistant": "2023.12.0",
+  "homeassistant": "2024.2.0",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "ADT Pulse",
-  "homeassistant": "2023.1.0",
+  "homeassistant": "2023.12.0",
   "render_readme": true
 }


### PR DESCRIPTION
## 0.4.1 (2024-02-24)
* bump pyadtpulse to 1.2.7. This will:

- perform a full re-login approximately every 6 hours
    - speed up zone and alarm update times
    - allow Home Assistant to just refresh updated zones/alarm instead all all entities
    - fix various "you have not logged in yet" errors

* have connection status show authentication errors
* correctly handle coordinator update authentication errors to perform configuration reauthentication flow
