### PR TITLE
Compatibility for HA 2025

### DIFF
--- a/custom_components/adtpulse/manifest.json
+++ b/custom_components/adtpulse/manifest.json
@@ -9,7 +9,7 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/rsnodgrass/hass-adtpulse/issues",
     "requirements": [
-        "pyadtpulse>=1.2.9"
+        "pyadtpulse>=1.2.10"
     ],
-    "version": "0.4.6"
+    "version": "0.4.7"
 }


### PR DESCRIPTION
- See paired PR for pyadtpulse here https://github.com/rsnodgrass/pyadtpulse/pull/41
- Once a new version of that package is published this PR will use it, this should resolve issues with uvloop dependency on python 3.13
- Thread on the issue: https://community.home-assistant.io/t/adt-pulse-integration/10160/382